### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/adv/security/smart_contract_audit.mdx
+++ b/adv/security/smart_contract_audit.mdx
@@ -27,7 +27,7 @@ The Obol Manager contracts are responsible for distributing validator rewards an
 
 ## About **zachobront**
 
-Zach Obront is an independent smart contract security researcher. He serves as a Lead Senior Watson at Sherlock, a Security Researcher at Spearbit, and has identified multiple critical severity bugs in the wild, including in a Top 5 Protocol on Immunefi. You can say hi on Twitter at [@zachobront](http://twitter.com/zachobront).
+Zach Obront is an independent smart contract security researcher. He serves as a Lead Senior Watson at Sherlock, a Security Researcher at Spearbit, and has identified multiple critical severity bugs in the wild, including in a Top 5 Protocol on Immunefi. You can say hi on Twitter at [@zachobront](http://x.com/zachobront).
 
 ## Summary & Scope
 

--- a/learn/intro/faq.mdx
+++ b/learn/intro/faq.mdx
@@ -16,7 +16,7 @@ Yes, please see the token page[../../gov/governance/obol-token.md] for details a
 
 ### Where can I learn more about Distributed Validators?
 
-Have you checked out our [blog site](https://blog.obol.tech) and [twitter](https://twitter.com/ObolNetwork) yet? Maybe join our [discord](https://discord.gg/n6ebKsX46w) too.
+Have you checked out our [blog site](https://blog.obol.tech) and [twitter](https://x.com/ObolNetwork) yet? Maybe join our [discord](https://discord.gg/n6ebKsX46w) too.
 
 ### Where does the name Charon come from?
 


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.