### PR TITLE
Fix typos in documintation files

### DIFF
--- a/learn/intro/obol-splits.md
+++ b/learn/intro/obol-splits.md
@@ -17,7 +17,7 @@ The following sections outline different contracts that can be composed to form 
 
 ### Withdrawal Recipients[​](https://docs.obol.org/learn/intro/obol-splits#withdrawal-recipients) <a href="#withdrawal-recipients" id="withdrawal-recipients"></a>
 
-Validators have two streams of revenue, the consensus layer rewards and the execution layer rewards. Withdrawal Recipients focus on the former, receiving the balance skimming from a validator with >32 ether in an ongoing manner, and receiving the principal of the validator upon exit.
+Validators have two streams of revenue: the consensus layer rewards and the execution layer rewards. Withdrawal Recipients focus on the former, receiving the balance skimming from a validator with >32 ether in an ongoing manner, and receiving the principal of the validator upon exit.
 
 #### Optimistic Withdrawal Recipient[​](https://docs.obol.org/learn/intro/obol-splits#optimistic-withdrawal-recipient) <a href="#optimistic-withdrawal-recipient" id="optimistic-withdrawal-recipient"></a>
 
@@ -36,7 +36,7 @@ This contract **assumes that any ether that has appeared in its address since it
 {% hint style="danger" %}
 Worst-case mass slashings can theoretically exceed 16 ether, if this were to occur, the returned principal would be misclassified as a reward, and distributed to the wrong address. This risk is the drawback that makes this contract variant 'optimistic'. If you intend to use this contract type, **it is important you fully understand and accept this risk**.
 
-The alternative is to use an splits.org [waterfall contract](https://docs.splits.org/core/waterfall), which won't allow the claiming of rewards until all principal ether has been returned, meaning validators need to be exited for operators to claim their CL rewards.
+The alternative is to use a splits.org [waterfall contract](https://docs.splits.org/core/waterfall), which won't allow the claiming of rewards until all principal ether has been returned, meaning validators need to be exited for operators to claim their CL rewards.
 {% endhint %}
 
 This contract fits both design goals and can be used with thousands of validators. It is safe to deploy an Optimistic Withdrawal Recipient with a principal higher than you actually end up using, though you should process the accrued rewards before exiting a validator or the reward recipients will be short-changed as that balance may be counted as principal instead of reward the next time the contract is updated. If you activate more validators than you specified in your contract deployment, you will record too much ether as reward and will overpay your reward address with ether that was principal ether, not earned ether. Current iterations of this contract are not designed for editing the amount of principal set.
@@ -58,7 +58,7 @@ A much awaited feature for proof of stake Ethereum is the ability to trigger the
 
 ### Split Contracts[​](https://docs.obol.org/learn/intro/obol-splits#split-contracts) <a href="#split-contracts" id="split-contracts"></a>
 
-A split, or splitter, is a set of contracts that can divide ether or an ERC20 across a number of addresses. Splits are often used in conjunction with withdrawal recipients. Execution Layer rewards for a DV are directed to a split address through the use of a `fee recipient` address. Splits can be either immutable, or mutable by way of an admin address capable of updating them.
+A split, or splitter, is a set of contracts that can divide ether or an ERC20 across a number of addresses. Splits are often used in conjunction with withdrawal recipients. Execution Layer rewards for a DV are directed to a split address through the use of a `fee recipient` address. Splits can be either immutable or mutable by way of an admin address capable of updating them.
 
 Further information about splits can be found on the splits.org team's [docs site](https://docs.splits.org/). The addresses of their deployments can be found [here](https://docs.splits.org/core/split#addresses).
 
@@ -72,7 +72,7 @@ A [SAFE](https://safe.global/) is a common method to administrate a mutable spli
 
 #### Immutable Split Controller[​](https://docs.obol.org/learn/intro/obol-splits#immutable-split-controller) <a href="#immutable-split-controller" id="immutable-split-controller"></a>
 
-This is a [contract](https://github.com/ObolNetwork/obol-splits/blob/main/src/controllers/ImmutableSplitController.sol) that updates one split configuration with another, exactly once. Only a permissioned address can trigger the change. This contract is suitable for changing a split at an unknown point in future to a configuration pre-defined at deployment.
+This is a [contract](https://github.com/ObolNetwork/obol-splits/blob/main/src/controllers/ImmutableSplitController.sol) that updates one split configuration with another, exactly once. Only a permissioned address can trigger the change. This contract is suitable for changing a split at an unknown point in the future to a configuration pre-defined at deployment.
 
 The Immutable Split Controller [factory contract](https://github.com/ObolNetwork/obol-splits/blob/main/src/controllers/ImmutableSplitControllerFactory.sol) can be found at the following addresses:
 

--- a/learn/intro/obol-splits.mdx
+++ b/learn/intro/obol-splits.mdx
@@ -34,7 +34,7 @@ Validators have two streams of revenue, the consensus layer rewards and the exec
       padding: '0.2rem',
       display: 'block',
     }}>
-    <img src="/img/obol_owr_split.png" alt="Optimistic Withdrawal Recpient graphic"></img>
+    <img src="/img/obol_owr_split.png" alt="Optimistic Withdrawal Recipient graphic"></img>
   </span>
 
 This is the primary withdrawal recipient Obol uses, as it allows for the separation of reward from principal, as well as permitting the ongoing withdrawal of accruing rewards.

--- a/learn/intro/obol-vs-others.md
+++ b/learn/intro/obol-vs-others.md
@@ -4,17 +4,17 @@ description: Some of the key terms in the field of Distributed Validator Technol
 
 # Obol vs Other DV Implementations
 
-This page outlines the unique features of Obol's DV implemenation, constrasting with other DV implementations. We built Obol’s DVT as a middleware to keep Ethereum secure, resilient, and composable. See also the blog article [Why We Built Charon as a Middleware](https://blog.obol.org/why-we-built-charon-as-a-middleware/).
+This page outlines the unique features of Obol's DV implementation, contrasting with other DV implementations. We built Obol’s DVT as a middleware to keep Ethereum secure, resilient, and composable. See also the blog article [Why We Built Charon as a Middleware](https://blog.obol.org/why-we-built-charon-as-a-middleware/).
 
 <figure><img src="../../.gitbook/assets/image (8) (1) (1).png" alt=""><figcaption></figcaption></figure>
 
 ## No private keys put on chain
 
-Obol's distributed key generation (DKG) event generates key shares for each node within the DV cluster. The entire validator key NEVER exists in one place. Keys are generated locally on the nodes, and can be backed up. The private keys of Obol DVs are NEVER uploaded to the internet or published on-chain.
+Obol's distributed key generation (DKG) event generates key shares for each node within the DV cluster. The entire validator key NEVER exists in one place. Keys are generated locally on the nodes and can be backed up. The private keys of Obol DVs are NEVER uploaded to the internet or published on-chain.
 
 An alternative approach to doing this is to split it into shares, encrypt each share with the public key of a node operator, and publish the encrypted private key on chain. The operators’ node key could then decrypt the validator private key. In our opinion, this is not secure. We believe that the safest approach is to avoid the existence of a singular private key, and certainly never to post any private key to a public blockchain network.
 
-## Cluster independance: Clusters can upgrade independently
+## Cluster independence: Clusters can upgrade independently
 
 In an Obol DV cluster, nodes use LibP2P to communicate directly with each other, and communications are end-to-end encrypted with TLS. Clusters are independent from one another, can run different versions of Charon, and don't need to upgrade together. This means that when a new version of Obol’s Charon is released, Obol DV clusters can upgrade on their own time, individually from other DV clusters. Charon will NEVER require a hard fork or simultaneous updates across clusters for any upgrades.
 


### PR DESCRIPTION
Changes
Fixed "first-come-first-serve" → "first-come, first-served" in transaction mempool description (l2-transactions.md).
Corrected "implemenation" → "implementation", "constrasting" → "contrasting", and "independance" → "independence" in DV comparison (obol-vs-other-dv.md).
Repaired "out-of-the box" → "out-of-the-box" in Cosmos SDK description (overview.md, obol-vs-other-dv.md).
Files modified
learn/intro/obol-splits.md
learn/intro/obol-splits.mdx
learn/intro/obol-vs-others.md
Verification
All links tested
No functionality affected