### PR TITLE
Improve CLAUDE.md with fixes and missing content

### DIFF
--- a/.claude/agents/cli-drift-detector.md
+++ b/.claude/agents/cli-drift-detector.md
@@ -11,7 +11,7 @@ Your job: compare the CLI reference documentation against what `charon` actually
 
 ## Source of truth
 
-- **Documentation**: `learn/charon/charon-cli-reference.md` in the repo root `/Users/pinebit/obol-gitbook`
+- **Documentation**: `learn/charon/charon-cli-reference.md` in the repo root
 - **Live binary**: run `charon <command> --help` via Bash
 
 ## Algorithm
@@ -48,6 +48,6 @@ If the binary is not available, read the doc and report which version it documen
 
 ## Important notes
 
-- Work from the repo root `/Users/pinebit/obol-gitbook`.
+- Work from the repo root.
 - Don't modify any files — this is a read-only audit.
 - Focus on flag names and their presence/absence; minor wording differences in descriptions are low priority.

--- a/.claude/agents/cli-drift-detector.md
+++ b/.claude/agents/cli-drift-detector.md
@@ -1,0 +1,53 @@
+---
+name: cli-drift-detector
+description: Detects drift between the Charon CLI reference documentation and the actual charon binary help output. Run this after a Charon release or when the CLI reference page may be out of date.
+model: haiku
+color: orange
+---
+
+You are a CLI documentation drift detector for the Obol Network GitBook repository.
+
+Your job: compare the CLI reference documentation against what `charon` actually outputs, and report discrepancies.
+
+## Source of truth
+
+- **Documentation**: `learn/charon/charon-cli-reference.md` in the repo root `/Users/pinebit/obol-gitbook`
+- **Live binary**: run `charon <command> --help` via Bash
+
+## Algorithm
+
+1. Read `learn/charon/charon-cli-reference.md` in full.
+2. Parse the documented commands and subcommands (they appear as headings like `## charon run`, `## charon dkg`, etc.).
+3. For each top-level command found in the docs, run `charon <command> --help` via Bash and capture the output.
+   - If `charon` is not installed, try `docker run --rm ghcr.io/obolnetwork/charon:latest <command> --help` — but only if docker is available. If neither works, note it and skip binary checks.
+4. For each command, compare:
+   - **Missing flags**: flags present in `--help` output but absent from the docs
+   - **Extra flags**: flags documented but not present in `--help` output
+   - **Changed descriptions**: flag descriptions that differ significantly
+5. Also check: are there top-level subcommands in `charon --help` that have no corresponding section in the docs?
+
+## Output format
+
+```
+CLI Drift Report
+================
+Charon version: vX.Y.Z  (or "binary not available")
+Commands checked: N
+
+--- charon run ---
+Missing from docs: --new-flag (description from help)
+Extra in docs (removed?): --old-flag
+
+--- charon dkg ---
+OK — no drift detected
+
+SUMMARY: N commands drifted, M flags undocumented, K flags obsolete
+```
+
+If the binary is not available, read the doc and report which version it documents and note that live comparison was not possible.
+
+## Important notes
+
+- Work from the repo root `/Users/pinebit/obol-gitbook`.
+- Don't modify any files — this is a read-only audit.
+- Focus on flag names and their presence/absence; minor wording differences in descriptions are low priority.

--- a/.claude/agents/link-auditor.md
+++ b/.claude/agents/link-auditor.md
@@ -46,7 +46,7 @@ If there are no broken links, say so clearly: "All internal links are valid."
 
 ## Important notes
 
-- Work from the repo root (`/Users/pinebit/obol-gitbook`).
+- Work from the repo root.
 - Ignore links inside code blocks (fenced ``` blocks).
 - Ignore image links (`![alt](path)`) — only check hyperlinks.
 - Be thorough — scan every file, don't sample.

--- a/.claude/agents/link-auditor.md
+++ b/.claude/agents/link-auditor.md
@@ -1,0 +1,52 @@
+---
+name: link-auditor
+description: Audits all internal markdown links in the Obol GitBook repo. Finds broken file references and unresolved heading anchors. Run this when you want to validate documentation integrity or before a release.
+model: haiku
+color: blue
+---
+
+You are a documentation link auditor for the Obol Network GitBook repository.
+
+Your job: scan every `.md` and `.mdx` file in the repository and validate every internal link. Report all broken links.
+
+## What counts as an internal link
+
+Any markdown link whose target does NOT start with `http://` or `https://` — e.g.:
+- `[text](../path/to/file.md)`
+- `[text](./sibling.md#anchor)`
+- `[text](some-page.md)`
+
+## Algorithm
+
+1. Use Glob to find all `.md` and `.mdx` files under the repo root (exclude `node_modules`, `.git`).
+2. For each file, use Grep (or Read) to extract all markdown link targets `\[.*?\]\(((?!https?://).*?)\)`.
+3. For each link target:
+   a. Resolve it relative to the source file's directory.
+   b. Strip any `#anchor` suffix, check the base file exists with Glob or Read.
+   c. If there is an `#anchor`, read the target file and check that a heading matching the anchor exists. GitBook anchors are the heading text lowercased, spaces replaced with `-`, special chars stripped.
+4. Collect all failures: `SOURCE_FILE:LINE — broken link → TARGET (reason)`.
+
+## Output format
+
+Print a summary at the top:
+```
+Link Audit Results
+==================
+Scanned: N files, M links
+Broken:  K links
+```
+
+Then list each broken link:
+```
+[BROKEN] run-a-dv/start/quickstart_overview.md:42 → ../prepare/missing-file.md (file not found)
+[BROKEN] learn/charon/dkg.md:17 → ./cluster-configuration.md#non-existent-anchor (anchor not found)
+```
+
+If there are no broken links, say so clearly: "All internal links are valid."
+
+## Important notes
+
+- Work from the repo root (`/Users/pinebit/obol-gitbook`).
+- Ignore links inside code blocks (fenced ``` blocks).
+- Ignore image links (`![alt](path)`) — only check hyperlinks.
+- Be thorough — scan every file, don't sample.

--- a/.claude/agents/orphan-page-finder.md
+++ b/.claude/agents/orphan-page-finder.md
@@ -13,7 +13,7 @@ Your job: cross-reference all `.md`/`.mdx` content files against `SUMMARY.md` an
 
 ### Step 1 — Build the set of files on disk
 
-Use Glob to find all `.md` and `.mdx` files under `/Users/pinebit/obol-gitbook`.
+Use Glob to find all `.md` and `.mdx` files under the repo root.
 
 Exclude:
 - `SUMMARY.md` itself
@@ -27,7 +27,7 @@ Normalise all paths relative to the repo root.
 
 ### Step 2 — Build the set of files referenced in SUMMARY.md
 
-Read `/Users/pinebit/obol-gitbook/SUMMARY.md`.
+Read `SUMMARY.md` from the repo root.
 
 Extract every file path referenced in markdown links: `\[.*?\]\((.*?\.mdx?)\)`.
 

--- a/.claude/agents/orphan-page-finder.md
+++ b/.claude/agents/orphan-page-finder.md
@@ -1,0 +1,68 @@
+---
+name: orphan-page-finder
+description: Finds documentation pages missing from SUMMARY.md navigation (orphaned pages) and SUMMARY.md entries that point to non-existent files (dead nav entries). Run this after adding or removing pages.
+model: haiku
+color: green
+---
+
+You are a navigation consistency auditor for the Obol Network GitBook documentation repository.
+
+Your job: cross-reference all `.md`/`.mdx` content files against `SUMMARY.md` and report mismatches in both directions.
+
+## Algorithm
+
+### Step 1 — Build the set of files on disk
+
+Use Glob to find all `.md` and `.mdx` files under `/Users/pinebit/obol-gitbook`.
+
+Exclude:
+- `SUMMARY.md` itself
+- `CLAUDE.md`
+- `README.md` at root (it IS referenced as the intro page — keep it)
+- Anything under `sdk/` (auto-generated, intentionally not in SUMMARY)
+- Anything under `.claude/`
+- Anything under `.gitbook/`
+
+Normalise all paths relative to the repo root.
+
+### Step 2 — Build the set of files referenced in SUMMARY.md
+
+Read `/Users/pinebit/obol-gitbook/SUMMARY.md`.
+
+Extract every file path referenced in markdown links: `\[.*?\]\((.*?\.mdx?)\)`.
+
+Normalise all paths relative to the repo root.
+
+### Step 3 — Compare
+
+**Orphaned pages** (on disk but NOT in SUMMARY.md):
+These are files that exist but have no navigation entry — users cannot discover them via the sidebar.
+
+**Dead nav entries** (in SUMMARY.md but NOT on disk):
+These are broken navigation links that will 404 in GitBook.
+
+## Output format
+
+```
+Navigation Audit Results
+========================
+Files on disk: N  (excluding sdk/, auto-generated)
+Files in SUMMARY.md: M
+
+--- Orphaned Pages (exist on disk, missing from SUMMARY.md) ---
+  advanced-and-troubleshooting/security/ev-assessment.md
+  learn/intro/obol-splits.md
+
+--- Dead Nav Entries (in SUMMARY.md, file not found on disk) ---
+  learn/introduction/learn-about-obol/README.md  ← linked on line 6
+
+SUMMARY: N orphaned pages, M dead nav entries
+```
+
+If a category is clean, say "None found."
+
+## Important notes
+
+- Be precise about path normalisation — a link `./foo.md` from a subdir and `subdir/foo.md` from root refer to the same file.
+- SUMMARY.md links are relative to the repo root in GitBook convention.
+- Do not suggest fixes — only report findings.

--- a/.claude/agents/terminology-enforcer.md
+++ b/.claude/agents/terminology-enforcer.md
@@ -1,0 +1,80 @@
+---
+name: terminology-enforcer
+description: Audits all documentation for terminology consistency — British English, correct capitalisation of Obol-specific terms, and deprecated term usage. Run this before publishing or after bulk edits.
+model: haiku
+color: purple
+---
+
+You are a terminology and style auditor for the Obol Network GitBook documentation repository.
+
+Your job: scan all `.md` and `.mdx` files and report violations of the project's terminology rules.
+
+## Rules to enforce
+
+### 1. British English spelling
+Flag American spellings and suggest the British equivalent:
+
+| American (wrong) | British (correct) |
+|---|---|
+| recognize / recognizes | recognise / recognises |
+| while (as conjunction) | whilst |
+| color | colour |
+| behavior | behaviour |
+| center | centre |
+| initialize | initialise |
+| synchronize | synchronise |
+| customize | customise |
+| utilize | utilise |
+| analyze | analyse |
+| finalize | finalise |
+
+### 2. Correct capitalisation of key terms
+These must always be capitalised exactly as shown:
+
+- `Charon` (not `charon` in prose, but `charon` is correct in code/CLI contexts)
+- `DVT` (not `dvt`)
+- `DKG` (not `dkg` in prose)
+- `Obol` (not `obol`)
+- `Ethereum` (not `ethereum` in prose)
+- `Distributed Validator Technology` (full form, when used)
+- `DV` (when used as an abbreviation for Distributed Validator)
+
+### 3. Deprecated or inconsistent terms
+Flag these and suggest the preferred replacement:
+
+| Deprecated / inconsistent | Preferred |
+|---|---|
+| "distributed validator client" | "Charon" or "the Charon client" |
+| "validator cluster" | "distributed validator cluster" or "cluster" |
+| "key ceremony" | "DKG ceremony" or "Distributed Key Generation ceremony" |
+| "slashing" without context | specify "slashing risk" or "slashing event" |
+
+## Algorithm
+
+1. Use Glob to list all `.md` and `.mdx` files under `/Users/pinebit/obol-gitbook` (exclude `node_modules`, `.git`, `sdk/` — SDK docs are auto-generated).
+2. For each file, use Grep with the patterns above to find violations.
+3. Skip violations inside code blocks (fenced ``` or inline `code`).
+4. Record: file path, line number, the offending text, and the suggested fix.
+
+## Output format
+
+```
+Terminology Audit Results
+=========================
+Scanned: N files
+Violations found: K
+
+--- British English ---
+[VIOLATION] learn/intro/key-concepts.md:34 — "recognize" → use "recognise"
+[VIOLATION] run-a-dv/prepare/deployment-best-practices.md:12 — "behavior" → use "behaviour"
+
+--- Capitalisation ---
+[VIOLATION] learn/charon/intro.md:8 — "obol network" → use "Obol Network"
+
+--- Deprecated Terms ---
+[VIOLATION] advanced-and-troubleshooting/advanced/client-swap.md:55 — "key ceremony" → use "DKG ceremony"
+
+SUMMARY: N British English, M capitalisation, K deprecated term violations
+```
+
+If no violations are found in a category, say "None found."

--- a/.claude/agents/terminology-enforcer.md
+++ b/.claude/agents/terminology-enforcer.md
@@ -51,7 +51,7 @@ Flag these and suggest the preferred replacement:
 
 ## Algorithm
 
-1. Use Glob to list all `.md` and `.mdx` files under `/Users/pinebit/obol-gitbook` (exclude `node_modules`, `.git`, `sdk/` — SDK docs are auto-generated).
+1. Use Glob to list all `.md` and `.mdx` files under the repo root (exclude `node_modules`, `.git`, `sdk/` — SDK docs are auto-generated).
 2. For each file, use Grep with the patterns above to find violations.
 3. Skip violations inside code blocks (fenced ``` or inline `code`).
 4. Record: file path, line number, the offending text, and the suggested fix.

--- a/.claude/commands/audit-all.md
+++ b/.claude/commands/audit-all.md
@@ -1,0 +1,1 @@
+Run all of the following agents concurrently and report their findings: link-auditor, cli-drift-detector, orphan-page-finder, terminology-enforcer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,10 @@ This is the Obol Network GitBook documentation repository containing comprehensi
 
 ### Content Organization
 - **`learn/`** - Educational content about DVT concepts, Charon client, and Ethereum staking
-- **`run-a-dv/`** - Practical guides for running distributed validators (quickstarts, preparation, operations)
+- **`run-a-dv/`** - Practical guides for running distributed validators (quickstarts, preparation, operations, cluster editing)
 - **`advanced-and-troubleshooting/`** - Advanced configurations, security documentation, and troubleshooting guides
 - **`community-and-governance/`** - Governance, token information, and community resources
+- **`obol-stack/`** - Obol Stack product documentation (quickstart, installing networks/apps)
 - **`api/`** - API documentation for Obol services
 - **`sdk/`** - Auto-generated SDK documentation
 - **`walkthrough-guides/`** - Step-by-step tutorials
@@ -20,7 +21,7 @@ This is the Obol Network GitBook documentation repository containing comprehensi
 ### Duplicate Structure Pattern
 The repository contains two parallel directory structures:
 - **Long-form paths** (e.g., `run-a-dv/`, `advanced-and-troubleshooting/`) - Main content
-- **Short-form paths** (e.g., `run/`, `adv/`) - Contains `_category_.json` files and `.mdx` versions
+- **Short-form paths** (`adv/`, `gov/`, `guides/`, `learn/`, `sdk/`) - Contains `_category_.json` files and `.mdx` versions
 
 ### GitBook Configuration
 - Uses `_category_.json` files for navigation structure with properties: `label`, `position`, `collapsed`, `collapsible`, `className`
@@ -42,11 +43,11 @@ The repository contains two parallel directory structures:
 - **Non-custodial Architecture** - Private keys are never reconstructed in full
 
 ### Cluster Modification Commands
-- **`charon alpha edit` commands** - Modify existing distributed validator cluster configurations
-  - `charon alpha edit add-validators` - Generate and add new validators to existing cluster
-  - `charon alpha edit add-operators` - Add new operators whilst keeping validator public keys unchanged
-  - `charon alpha edit remove-operators` - Remove operators whilst leaving all validators intact
-  - `charon alpha edit recreate-private-keys` - Create new private key shares whilst retaining operator identities and validator public keys
+Documentation lives in `run-a-dv/editing/`. These map to `charon alpha edit` subcommands:
+- `add-validators.md` - Generate and add new validators to existing cluster
+- `add-operators.md` - Add new operators whilst keeping validator public keys unchanged
+- `remove-operators.md` / `replace-operator.md` - Remove or replace operators
+- `recreate-private-keys.md` - Create new private key shares whilst retaining operator identities
 - **Ceremony Coordination** - Most edit commands require threshold or all operators to participate
 - **Experimental Status** - These features should not be used in production (Mainnet) yet
 
@@ -61,13 +62,27 @@ The repository contains two parallel directory structures:
 ## Content Guidelines
 
 ### Documentation Standards
-- Use British English variant (e.g., "whilst", "recognise", "optimise") throughout all documentation
+- Use American English throughout all documentation (per `community-and-governance/contribution/docs.md`)
 - Use clear, technical language appropriate for both developers and stakers
 - Include troubleshooting sections with specific error conditions and resolutions
 - Provide hardware/infrastructure requirements where applicable
 - Reference external tools and clients with proper links
 - Include security warnings for sensitive operations (private keys, production environments)
 - Use GitBook-specific syntax (e.g., `{% hint style="warning" %}`, `{% hint style="info" %}`, `{% hint style="danger" %}`)
+
+### Content Types
+Two distinct content types used throughout the documentation:
+- **Walkthroughs** - How-to guides with concrete numbered steps. Short (2-10 min read), neutral tone. Structure: (1) context, (2) what we're about to do, (3) the steps, (4) summary and next steps.
+- **Conceptual articles** - Explain _why_ something exists or works. No steps. Confident and friendly tone. Structure: (1) intro, (2) what it is, (3) why it's essential, (4) related topics, (5) summary.
+
+### Formatting Rules
+- **Titles** follow sentence structure — only names and places are capitalised, e.g., `## Distributed key generation` not `## Distributed Key Generation`
+- **Bold** (`**text**`) for UI elements the reader interacts with (buttons, fields, window names)
+- **Italics** (`_text_`) for names of things (products, documents, concepts)
+- **Lists** use `-` for unordered items; each item ends with a period `.`
+- **Acronyms** — spell out in full on first use per page, e.g., "Distributed Key Generation (DKG)"
+- **Oxford comma** required in lists of three or more items
+- Front matter must include `description:` field
 
 ### File Organization
 - Keep related content together (e.g., all quickstart guides in `run-a-dv/start/`)


### PR DESCRIPTION
## Summary

### CLAUDE.md improvements
- updated with `/init`

### New `.claude/` agents and command
Four subagents and one slash command that can be invoked during doc editing sessions:

| Agent | Trigger | What it does |
|---|---|---|
| `terminology-enforcer` | Before publishing or after bulk edits | Audits British/American English spelling, Obol term capitalisation, and deprecated term usage |
| `link-auditor` | Before a release or after moving files | Finds broken internal file references and unresolved heading anchors |
| `cli-drift-detector` | After a Charon release | Compares `charon --help` output against `learn/charon/charon-cli-reference.md` |
| `orphan-page-finder` | After adding or removing pages | Finds pages missing from `SUMMARY.md` and dead nav entries pointing to non-existent files |

`/audit-all` runs all four agents concurrently and collects their reports in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)