### PR TITLE
docs: fix broken markdown link in FAQ

### DIFF
--- a/learn/intro/faq.mdx
+++ b/learn/intro/faq.mdx
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 
 ### Does Obol have a token?
 
-Yes, please see the token page[../../gov/governance/obol-token.md] for details about the OBOL Token and our [announcement](https://blog.obol.org/airdrop/) for details about the community airdrop that took place in January 2025. The official token contract address is 0x0B010000b7624eb9B3DfBC279673C76E9D29D5F7. 
+Yes, please see the [token page](../../gov/governance/obol-token.md) for details about the OBOL Token and our [announcement](https://blog.obol.org/airdrop/) for details about the community airdrop that took place in January 2025. The official token contract address is 0x0B010000b7624eb9B3DfBC279673C76E9D29D5F7. 
 
 ### Where can I learn more about Distributed Validators?
 


### PR DESCRIPTION
Fixed incorrect markdown link syntax for the token page reference in the FAQ section. The link was using `page[link]` instead of `[page](link)` format.