### PR TITLE
docs: builder block selection and chain_split_halt guidance

### DIFF
--- a/adv/advanced/quickstart-builder-api.mdx
+++ b/adv/advanced/quickstart-builder-api.mdx
@@ -91,7 +91,6 @@ The following flags need to be configured on your chosen consensus client. A Fla
         --payload-builder-url="https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net"`}
       </code>
     </pre>
-    You should also consider adding <code>--local-block-value-boost=3</code> as a flag, to favor locally built blocks if they are withing 3% in value of the relay block, to improve the chances of a successful proposal.
   </TabItem>
   <TabItem value="lodestar" label="Lodestar">
     Lodestar can communicate with a single relay directly:
@@ -140,11 +139,15 @@ The following flags need to be configured on your chosen validator client
   <TabItem value="lodestar" label="Lodestar">
     <pre>
       <code>
-    {String.raw`node ./lodestar validator --builder="true" --builder.selection="builderonly"`}
+    {String.raw`node ./lodestar validator --builder="true" --builder.selection="builderalways"`}
       </code>
     </pre>
   </TabItem>
 </Tabs>
+
+:::info
+For at-scale deployments, additional flags should be configured on the consensus or validator client to ensure builder bids are preferred over locally-built blocks whenever available. See [Builder Block Selection](../../run/prepare/deployment-best-practices.mdx#builder-block-selection) in the deployment best practices for the recommended flag per client.
+:::
 
 ## Verify your cluster is correctly configured
 

--- a/advanced-and-troubleshooting/advanced/enable-mev.md
+++ b/advanced-and-troubleshooting/advanced/enable-mev.md
@@ -79,8 +79,6 @@ nimbus_beacon_node \
       --payload-builder=true \
       --payload-builder-url="https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net"
 ```
-
-You should also consider adding `--local-block-value-boost=3` as a flag, to favor locally built blocks if they are withing 3% in value of the relay block, to improve the chances of a successful proposal.
 {% endtab %}
 
 {% tab title="Lodestar" %}
@@ -123,10 +121,14 @@ nimbus_validator_client --payload-builder=true
 
 {% tab title="Lodestar" %}
 ```
-node ./lodestar validator --builder="true" --builder.selection="builderonly"
+node ./lodestar validator --builder="true" --builder.selection="builderalways"
 ```
 {% endtab %}
 {% endtabs %}
+
+{% hint style="info" %}
+For at-scale deployments, additional flags should be configured on the consensus or validator client to ensure builder bids are preferred over locally-built blocks whenever available. See [Builder Block Selection](../../run-a-dv/prepare/deployment-best-practices.md#builder-block-selection) in the deployment best practices for the recommended flag per client.
+{% endhint %}
 
 ### Verify your cluster is correctly configured <a href="#verify-your-cluster-is-correctly-configured" id="verify-your-cluster-is-correctly-configured"></a>
 

--- a/run-a-dv/prepare/deployment-best-practices.md
+++ b/run-a-dv/prepare/deployment-best-practices.md
@@ -81,6 +81,20 @@ MEV relays are configured at the Consensus Layer or MEV-boost client level. Refe
 
 Use Charon's [`test mev` command](./test-a-cluster.md#test-mev-relay) to test a number of your preferred relays, and select the two or three relays with the lowest latency to your node(s), you do not need to have the same relays on each node in a cluster.
 
+## Builder Block Selection
+
+By default, most consensus clients apply a comparison factor or value boost when evaluating builder bids against locally-built blocks, which can cause a local block to be selected even when a builder bid is available. For at-scale deployments aiming to maximize MEV capture and consistent proposal behavior, configure your consensus client to never prefer locally-built blocks over builder bids.
+
+The relevant flags vary by consensus client:
+
+- **Teku**: `--validators-builder-bid-compare-factor=0`.
+- **Prysm**: `--local-block-value-boost=0`.
+- **Nimbus**: `--local-block-value-boost=0`.
+- **Lighthouse**: `--prefer-builder-proposals`.
+- **Lodestar**: `--builder.selection=builderalways` (set on the validator client).
+
+With these settings the consensus client uses a builder block whenever one is available, only falling back to a locally-built block if no valid bid is returned from any configured relay in time.
+
 ## Client Diversity
 
 Obol clusters should consist of a mix of different consensus, execution, and validator clients. Charon can't [detect client failures](../../learn/further-reading/ethereum_and_dvt.md#deep-dive-into-dvt-and-charons-architecture) if all nodes are using the same client. At a minimum, no single client should comprise the [threshold](../../learn/charon/cluster-configuration.md#cluster-size-and-resilience) of nodes in the cluster.

--- a/run-a-dv/prepare/deployment-best-practices.md
+++ b/run-a-dv/prepare/deployment-best-practices.md
@@ -110,6 +110,10 @@ Remote signers can be included as well, such as Web3signer or Dirk. A diversity 
 
 Tested client combinations can be found in the [release notes](https://github.com/ObolNetwork/charon/releases) for each Charon version.
 
+As an additional safeguard against client bugs that could produce a chain split, Charon's `chain_split_halt` feature has peers compare the leader's source and target votes against attester data from their own beacon node before participating in QBFT consensus. If the votes disagree, the peer refuses to participate, preventing the cluster from signing an attestation on the wrong fork. This trades some liveness (peers may need to wait for their local beacon node, and contentious forks can result in no attestation) for stronger safety against signing through a chain split.
+
+The feature is currently in alpha and is not enabled by default. To enable it, add `--feature-set-enable=chain_split_halt` to your `charon run` command.
+
 ## Execution Layer Configuration
 
 When available on the EL client (e.g [Nethermind](../../advanced-and-troubleshooting/troubleshooting/client_configurations.md#nethermind)), blob inclusion for locally-built blocks should be set to 0. Setting blob count to 0 for locally-built blocks avoids the additional latency of gathering blob transactions, which matters when falling back from MEV relay blocks under time pressure.

--- a/run-a-dv/prepare/deployment-best-practices.md
+++ b/run-a-dv/prepare/deployment-best-practices.md
@@ -85,15 +85,15 @@ Use Charon's [`test mev` command](./test-a-cluster.md#test-mev-relay) to test a 
 
 By default, most consensus clients apply a comparison factor or value boost when evaluating builder bids against locally-built blocks, which can cause a local block to be selected even when a builder bid is available. For at-scale deployments aiming to maximize MEV capture and consistent proposal behavior, configure your consensus client to never prefer locally-built blocks over builder bids.
 
-The relevant flags vary by consensus client:
+The relevant flags vary by consensus client. The flags below either force builder-always selection or remove the default local-block bias, depending on what the client supports:
 
-- **Teku**: `--validators-builder-bid-compare-factor=0`.
-- **Prysm**: `--local-block-value-boost=0`.
-- **Nimbus**: `--local-block-value-boost=0`.
-- **Lighthouse**: `--prefer-builder-proposals`.
-- **Lodestar**: `--builder.selection=builderalways` (set on the validator client).
+- **Teku**: `--builder-bid-compare-factor=BUILDER_ALWAYS` (set on the beacon node). Forces builder-always selection.
+- **Lighthouse**: `--prefer-builder-proposals` (set on the validator client). Forces builder-always selection.
+- **Lodestar**: `--builder.selection=builderalways` (set on the validator client). Forces builder-always selection.
+- **Prysm**: `--local-block-value-boost=0` (set on the beacon node). Removes the default 10% local-block bias so builder and local bids compete on equal value, but a higher-value local block can still be selected. Prysm has no builder-always mode.
+- **Nimbus**: `--local-block-value-boost=0` (set on the beacon node). Same caveat as Prysm. Note that the Nimbus team recommends a non-zero value to mitigate the risk of a relay failing to publish the advertised block.
 
-With these settings the consensus client uses a builder block whenever one is available, only falling back to a locally-built block if no valid bid is returned from any configured relay in time.
+Always preferring the builder maximizes MEV capture but increases the risk of a missed proposal if a relay is slow, returns a bad bid, or fails to publish the block. Operators that prioritize proposal reliability over MEV capture may instead keep a small local-block boost (e.g. `--local-block-value-boost=3` on Prysm/Nimbus, or a comparable percentage factor on Teku) as a liveness safety margin.
 
 ## Client Diversity
 


### PR DESCRIPTION
## Summary

- Add a Builder Block Selection section to deployment best practices listing the per-client flag for preferring builder bids over locally-built blocks (Teku, Prysm, Nimbus, Lighthouse, Lodestar).
- Update the MEV enable guides to remove the contradictory `--local-block-value-boost=3` recommendation and switch Lodestar from `builderonly` to `builderalways` for graceful fallback. Cross-references the new section.
- Mention Charon's `chain_split_halt` feature in the Client Diversity section as a complementary safeguard against client bugs causing a chain split, including the `--feature-set-enable=chain_split_halt` flag (alpha).