### PR TITLE
docs(ovm-predeploy): fix grantRoles bitmask in Cast example

### DIFF
--- a/advanced-and-troubleshooting/advanced/ovm-predeploy.md
+++ b/advanced-and-troubleshooting/advanced/ovm-predeploy.md
@@ -315,9 +315,10 @@ cast send $EXAMPLE_PULL_SPLIT_ADDRESS \
   --private-key $BACKEND_API_PRIVATE_KEY
 
 # Grant the customer the DEPOSIT_ROLE and WITHDRAWAL_ROLE
+# 0x21 = DEPOSIT_ROLE (0x20) | WITHDRAWAL_ROLE (0x01) = 33 in decimal
 cast send $EXAMPLE_OVM_ADDRESS \
   "grantRoles(address,uint256)" \
-  $EXAMPLE_CUSTOMER_ADDRESS 21 \
+  $EXAMPLE_CUSTOMER_ADDRESS 0x21 \
   --rpc-url $RPC_URL \
   --private-key $BACKEND_API_PRIVATE_KEY
 


### PR DESCRIPTION
## Summary

The Cast tab of the *Grant the customer the DEPOSIT_ROLE and WITHDRAWAL_ROLE* block in `ovm-predeploy.md` was passing `21` (decimal) as the `roles` bitmask. That value decodes to `0x15` = `WITHDRAWAL_ROLE | SET_BENEFICIARY_ROLE | SET_REWARD_ROLE`, which is a completely different combination than intended.

The Forge and TypeScript tabs were already correct (they use `WITHDRAWAL_ROLE | DEPOSIT_ROLE`, evaluated to `0x21`). The roles reference page (`assign-ovm-roles.md`) also documents this exact combination as `1 + 32 = 33` / `0x21`.

Switched the Cast example to `0x21` to match the hex notation used everywhere else in the doc, and added a one-line comment spelling out the bitmask.

## Test plan

- [x] Visual diff review of the change.
- [x] Confirm `0x21` matches `WITHDRAWAL_ROLE (0x01) | DEPOSIT_ROLE (0x20)` per the role table at the top of the same file and `assign-ovm-roles.md`.