### PR TITLE
feerecipient: document hardened sign and fetch behavior

### DIFF
--- a/advanced-and-troubleshooting/advanced/change-fee-recipient.md
+++ b/advanced-and-troubleshooting/advanced/change-fee-recipient.md
@@ -54,7 +54,7 @@ docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon
 ```
 
 {% hint style="info" %}
-`validator-public-keys` are the distributed validator public keys for which the fee recipient should be updated (find them in your `cluster-lock.json` file or on the DV Launchpad). `fee-recipient` is the new Ethereum address that will receive transaction tips and MEV rewards for the specified validators.
+`validator-public-keys` are the distributed validator public keys for which the fee recipient should be updated (find them in your `cluster-lock.json` file or on the DV Launchpad). `fee-recipient` is the new Ethereum address that will receive transaction tips and MEV rewards for the specified validators. The address must not be the zero address, and if supplied in mixed case it must match its EIP-55 checksum — both protect against typos that would irrecoverably send rewards to the wrong address.
 {% endhint %}
 
 {% hint style="info" %}
@@ -62,12 +62,12 @@ Operators do not need to sign simultaneously. The first operator to sign sets th
 {% endhint %}
 
 {% hint style="warning" %}
-Builder registrations are applied by timestamp. If you set `--timestamp` manually, choose a timestamp later than the current latest registration for the validators being updated. You can check the latest timestamp with `charon feerecipient list`. A registration with an older timestamp may be signed and submitted, but it will not replace a newer registration.
+Builder registrations are applied by timestamp. If you set `--timestamp` manually, choose a timestamp later than the current latest registration for the validators being updated. You can check the latest timestamp with `charon feerecipient list`. The `sign` command rejects a timestamp that is not later than the registration that currently has quorum on the remote API, since the resulting registration would never be applied. When joining an in-progress registration started by another operator, the in-progress timestamp and gas limit are adopted even if you pass different values, so all partial signatures aggregate — a warning is logged when your explicit flags are overridden.
 {% endhint %}
 
 ### Updating the gas limit
 
-Besides the fee recipient address, the `sign` command also allows you to modify the gas limit for builder registrations by passing the `--gas-limit` flag. If not set, the existing gas limit from the cluster lock or overrides file is used.
+Besides the fee recipient address, the `sign` command also allows you to modify the gas limit for builder registrations by passing the `--gas-limit` flag. If not set, the gas limit is taken from whichever source is most recent for the validator: the cluster lock, the local overrides file, or the registration that currently has quorum on the remote API. Consulting the remote API keeps operators with divergent local files signing the same gas limit.
 
 ```sh
 docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon:v1.10.0 feerecipient sign \
@@ -96,7 +96,11 @@ The `--validator-public-keys` flag is optional for the `fetch` command. If omitt
 {% endhint %}
 
 {% hint style="info" %}
-Fetched builder registrations are signature-verified before they are written or applied. A registration that fails verification is skipped and logged as a warning; registrations for other validators in the same fetch are still merged and written.
+Fetched builder registrations are signature-verified before they are written or applied. A registration that fails verification is skipped and logged as a warning; registrations for other validators in the same fetch are still merged and written. A fetched registration that is not newer than the existing override for the same validator is discarded with a warning.
+{% endhint %}
+
+{% hint style="info" %}
+A corrupt or invalid overrides file does not block fetching: `fetch` logs a warning, discards the unreadable content, and rebuilds the file from the valid existing entries and the fetched registrations. The file is written atomically, so an interrupted fetch cannot leave a truncated file behind.
 {% endhint %}
 
 ## 4. Verify the change

--- a/advanced-and-troubleshooting/advanced/change-fee-recipient.md
+++ b/advanced-and-troubleshooting/advanced/change-fee-recipient.md
@@ -61,6 +61,10 @@ docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon
 Operators do not need to sign simultaneously. The first operator to sign sets the timestamp to the current time. Subsequent operators automatically adopt the first signer's timestamp and registration data from the remote API, ensuring all partial signatures are compatible. If operators prefer to coordinate explicitly, they can agree on a Unix timestamp beforehand and pass it with the `--timestamp` flag.
 {% endhint %}
 
+{% hint style="warning" %}
+Builder registrations are applied by timestamp. If you set `--timestamp` manually, choose a timestamp later than the current latest registration for the validators being updated. You can check the latest timestamp with `charon feerecipient list`. A registration with an older timestamp may be signed and submitted, but it will not replace a newer registration.
+{% endhint %}
+
 ### Updating the gas limit
 
 Besides the fee recipient address, the `sign` command also allows you to modify the gas limit for builder registrations by passing the `--gas-limit` flag. If not set, the existing gas limit from the cluster lock or overrides file is used.
@@ -81,14 +85,18 @@ docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon
   --validator-public-keys="0xVALIDATOR_PUBKEY_1,0xVALIDATOR_PUBKEY_2"
 ```
 
-This writes the aggregated registrations to the overrides file at `.charon/builder_registrations_overrides.json`.
+This merges the aggregated registrations into the overrides file at `.charon/builder_registrations_overrides.json`. Existing overrides for validators that are not included in the fetch are preserved. If the file already contains an override for a fetched validator, Charon keeps the registration with the latest timestamp.
 
 {% hint style="info" %}
-If not enough operators have signed yet, the command will return an error. Coordinate with your cluster peers to ensure the threshold is met.
+If not enough operators have signed yet, the command logs that no fully signed builder registrations are available and does not write or update the overrides file. Coordinate with your cluster peers to ensure the threshold is met, then run `fetch` again.
 {% endhint %}
 
 {% hint style="info" %}
 The `--validator-public-keys` flag is optional for the `fetch` command. If omitted, it fetches registrations for all validators in the cluster.
+{% endhint %}
+
+{% hint style="info" %}
+Fetched builder registrations are signature-verified before they are written or applied. A registration that fails verification is skipped and logged as a warning; registrations for other validators in the same fetch are still merged and written.
 {% endhint %}
 
 ## 4. Verify the change
@@ -99,7 +107,7 @@ After fetching, confirm the updated fee recipients are in place:
 docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon:v1.10.0 feerecipient list
 ```
 
-You should see the new fee recipient address reflected for the updated validators.
+You should see the new fee recipient address reflected for the updated validators. If a validator still shows the previous fee recipient, check whether enough operators signed the same fee recipient, gas limit, and timestamp, and whether a newer registration already exists for that validator.
 
 ## Automatic application by Charon
 

--- a/learn/charon/charon-cli-reference.md
+++ b/learn/charon/charon-cli-reference.md
@@ -688,7 +688,7 @@ Use "charon feerecipient [command] --help" for more information about a command.
 
 ### Sign new fee recipient builder registrations
 
-The `charon feerecipient sign` command signs new builder registration messages to update the preferred fee recipient and publishes them to a remote API. A threshold of operators must run this command with matching parameters for the new fee recipient to take effect.
+The `charon feerecipient sign` command signs new builder registration messages to update the preferred fee recipient and publishes them to a remote API. A threshold of operators must run this command with matching parameters for the new fee recipient to take effect. Builder registrations are applied by timestamp, so a manually supplied `--timestamp` should be later than the current latest registration for the validator.
 
 ```markdown
 charon feerecipient sign --help
@@ -713,7 +713,9 @@ Flags:
 
 ### Fetch aggregated fee recipient builder registrations
 
-Once enough operators have signed their partial builder registrations, the `charon feerecipient fetch` command fetches and aggregates those with quorum from the remote API, writing them to a local JSON overrides file. The `charon run` command will then use this overrides file to apply the updated fee recipients.
+Once enough operators have signed their partial builder registrations, the `charon feerecipient fetch` command fetches and aggregates those with quorum from the remote API, then merges them into the local JSON overrides file. Existing overrides for validators outside the fetch are preserved, and the latest timestamp wins if an override already exists for a fetched validator. The `charon run` command will then use this overrides file to apply the updated fee recipients.
+
+If no fetched validator has enough partial signatures to reach quorum, the command logs that no fully signed builder registrations are available and does not write or update the overrides file. Fetched registrations are signature-verified before they are written or applied. A registration that fails verification is skipped and logged as a warning; registrations for other validators in the same fetch are still merged and written.
 
 ```markdown
 charon feerecipient fetch --help

--- a/learn/charon/charon-cli-reference.md
+++ b/learn/charon/charon-cli-reference.md
@@ -688,7 +688,7 @@ Use "charon feerecipient [command] --help" for more information about a command.
 
 ### Sign new fee recipient builder registrations
 
-The `charon feerecipient sign` command signs new builder registration messages to update the preferred fee recipient and publishes them to a remote API. A threshold of operators must run this command with matching parameters for the new fee recipient to take effect. Builder registrations are applied by timestamp, so a manually supplied `--timestamp` should be later than the current latest registration for the validator.
+The `charon feerecipient sign` command signs new builder registration messages to update the preferred fee recipient and publishes them to a remote API. A threshold of operators must run this command with matching parameters for the new fee recipient to take effect. Builder registrations are applied by timestamp, so a manually supplied `--timestamp` must be later than the current latest registration for the validator — the command rejects a timestamp that is not later than the registration that currently has quorum on the remote API. The fee recipient address must not be the zero address, and a mixed-case address must match its EIP-55 checksum.
 
 ```markdown
 charon feerecipient sign --help
@@ -699,7 +699,7 @@ Usage:
 
 Flags:
       --fee-recipient string            [REQUIRED] New fee recipient address to be applied to all specified validators.
-      --gas-limit uint                  Optional gas limit override for builder registrations. If not set, the existing gas limit from the cluster lock or overrides file is used.
+      --gas-limit uint                  Optional gas limit override for builder registrations. If not set, the most recent gas limit from the cluster lock, overrides file or remote API is used.
   -h, --help                            Help for sign
       --lock-file string                Path to the cluster lock file defining the distributed validator cluster. (default ".charon/cluster-lock.json")
       --overrides-file string           Path to the builder registrations overrides file. (default ".charon/builder_registrations_overrides.json")
@@ -715,7 +715,7 @@ Flags:
 
 Once enough operators have signed their partial builder registrations, the `charon feerecipient fetch` command fetches and aggregates those with quorum from the remote API, then merges them into the local JSON overrides file. Existing overrides for validators outside the fetch are preserved, and the latest timestamp wins if an override already exists for a fetched validator. The `charon run` command will then use this overrides file to apply the updated fee recipients.
 
-If no fetched validator has enough partial signatures to reach quorum, the command logs that no fully signed builder registrations are available and does not write or update the overrides file. Fetched registrations are signature-verified before they are written or applied. A registration that fails verification is skipped and logged as a warning; registrations for other validators in the same fetch are still merged and written.
+If no fetched validator has enough partial signatures to reach quorum, the command logs that no fully signed builder registrations are available and does not write or update the overrides file. Fetched registrations are signature-verified before they are written or applied. A registration that fails verification is skipped and logged as a warning; registrations for other validators in the same fetch are still merged and written. A fetched registration that is not newer than the existing override for the same validator is discarded with a warning. A corrupt or invalid existing overrides file does not block fetching — it is rebuilt from the valid entries and the fetched registrations, and the file is written atomically so an interrupted fetch cannot leave a truncated file behind.
 
 ```markdown
 charon feerecipient fetch --help


### PR DESCRIPTION
## Summary

- Document that `feerecipient fetch` merges newly fetched registrations into the existing overrides file (keeping the latest timestamp per validator) instead of overwriting it, and that unrelated validators' entries are preserved. A fetched registration that is not newer than the existing override is discarded with a warning.
- Document that a fetch with insufficient quorum logs and returns without touching the overrides file, rather than erroring.
- Document that fetched registrations are signature-verified, and that a registration failing verification is skipped and logged while the rest of the batch is still merged and written.
- Document that a corrupt or invalid overrides file does not block fetching (it is rebuilt), and that the file is written atomically.
- Document `feerecipient sign` validation: the fee recipient must not be the zero address, a mixed-case address must match its EIP-55 checksum, and a manually supplied `--timestamp` must be later than the registration that currently has quorum on the remote API (the command rejects it otherwise). When joining an in-progress registration, its timestamp and gas limit are adopted with a warning if explicit flags are overridden.
- Document that the default gas limit is resolved from the most recent of the cluster lock, the overrides file, and the current quorum registration on the remote API.
- Add guidance for troubleshooting a validator that still shows its previous fee recipient after fetching.

Charon PR: https://github.com/ObolNetwork/charon/pull/4571