### PR TITLE
Update split keys quickstart to match charon behavior

### DIFF
--- a/advanced-and-troubleshooting/advanced/quickstart-split.md
+++ b/advanced-and-troubleshooting/advanced/quickstart-split.md
@@ -57,7 +57,7 @@ Run the following docker command to split the keys (for mainnet):
 ```shell
 CHARON_VERSION=                # E.g. v1.10.0
 CLUSTER_NAME=                  # The name of the cluster you want to create.
-WITHDRAWAL_ADDRESS=            # The address you want to use for withdrawals (this is just for accuracy in your lock file, you can't change a withdrawal address for a validator that has already been deposited)
+WITHDRAWAL_ADDRESS=            # The address you want to use for withdrawals. It is recorded in the lock file and in the re-created deposit data files; it does not change the withdrawal address of a validator that has already been deposited.
 FEE_RECIPIENT_ADDRESS=         # The address you want to use for block reward and MEV payments.
 NODES=                         # The number of nodes in the cluster.
 
@@ -73,7 +73,7 @@ docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:${CHARON_VERSION} creat
    --publish
 ```
 
-The above command will create `validator_keys` along with `cluster-lock.json` in `./cluster` for each node. Deposit data is not re-created, as the existing validator is assumed to be deposited already.
+The above command will create `validator_keys` along with `cluster-lock.json` and `deposit-data-*.json` in `./cluster` for each node.
 
 Command output:
 
@@ -91,10 +91,15 @@ Created charon cluster:
 ├─ node[0-*]/                   # Directory for each node
 │  ├─ charon-enr-private-key    # Charon networking private key for node authentication
 │  ├─ cluster-lock.json         # Cluster lock defines the cluster lock file which is signed by all nodes
+│  ├─ deposit-data-*.json       # Deposit data files are used to activate a Distributed Validator on the DV Launchpad
 │  ├─ validator_keys            # Validator keystores and password
 │  │  ├─ keystore-*.json        # Validator private share key for duty signing
 │  │  ├─ keystore-*.txt         # Keystore password files for keystore-*.json
 ```
+
+{% hint style="warning" %}
+The `deposit-data-*.json` files are re-created and signed with the existing validator private keys, using the withdrawal addresses provided above. For a validator that is already activated, the on-chain withdrawal credentials remain unchanged — do not submit these deposit data files.
+{% endhint %}
 
 These split keys can now be used to start a Charon cluster.
 

--- a/advanced-and-troubleshooting/advanced/quickstart-split.md
+++ b/advanced-and-troubleshooting/advanced/quickstart-split.md
@@ -25,7 +25,7 @@ Split an existing Ethereum validator key into multiple key shares for use in an 
 ## Step 1. Prepare the existing keystore files
 
 {% hint style="info" %}
-Starting with Charon v1.8.0, you may not need to manually prepare the keystore files as described below. Charon can recursively search for keystore files in the specified directory and attempt to match the corresponding password files. The only case where this does not work is when you specify an exact list of withdrawal addresses; in that case, you must prepare the files manually and ensure the keystore indices match the order of the specified withdrawal addresses.
+Starting with Charon v1.8.0, you may not need to manually prepare the keystore files as described below. Charon can recursively search for keystore files in the specified directory and attempt to match the corresponding password files. The only case where this does not work is when you specify an exact list of withdrawal or fee recipient addresses; in that case, you must prepare the files manually and ensure the keystore indices match the order of the specified addresses.
 {% endhint %}
 
 Create a folder to hold the encrypted keystores, along with the passwords to decrypt them.
@@ -63,6 +63,7 @@ NODES=                         # The number of nodes in the cluster.
 
 docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:${CHARON_VERSION} create cluster \
    --name="${CLUSTER_NAME}" \
+   --cluster-dir=/opt/charon/cluster \
    --withdrawal-addresses="${WITHDRAWAL_ADDRESS}" \
    --fee-recipient-addresses="${FEE_RECIPIENT_ADDRESS}" \
    --split-existing-keys \
@@ -72,21 +73,21 @@ docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:${CHARON_VERSION} creat
    --publish
 ```
 
-The above command will create `validator_keys` along with `cluster-lock.json` in `./cluster` for each node.
+The above command will create `validator_keys` along with `cluster-lock.json` in `./cluster` for each node. Deposit data is not re-created, as the existing validator is assumed to be deposited already.
 
 Command output:
 
 ```shell
 ***************** WARNING: Splitting keys **********************
  Please make sure any existing validator has been shut down for
- at least 2 finalized epochs before starting the Charon cluster,
+ at least 2 finalized epochs before starting the charon cluster,
  otherwise slashing could occur.                               
 ****************************************************************
 
-Created Charon cluster:
+Created charon cluster:
  --split-existing-keys=true
 
-./cluster/
+/opt/charon/cluster/
 ├─ node[0-*]/                   # Directory for each node
 │  ├─ charon-enr-private-key    # Charon networking private key for node authentication
 │  ├─ cluster-lock.json         # Cluster lock defines the cluster lock file which is signed by all nodes

--- a/learn/charon/charon-cli-reference.md
+++ b/learn/charon/charon-cli-reference.md
@@ -109,7 +109,7 @@ Flags:
       --num-validators int                     The number of distributed validators needed in the cluster.
       --publish                                Publish lock file to obol-api.
       --publish-address string                 The URL to publish the lock file to. (default "https://api.obol.tech/v1")
-      --split-existing-keys                    Split an existing validator's private key into a set of distributed validator private key shares. Does not re-create deposit data for this key.
+      --split-existing-keys                    Split an existing validator's private key into a set of distributed validator private key shares. Deposit data files are re-created using the provided withdrawal addresses; do not submit deposits for validators that are already active.
       --split-keys-dir string                  Directory containing keys to split. Expects keys in keystore-*.json and passwords in keystore-*.txt. Requires --split-existing-keys.
       --target-gas-limit uint                  Preferred target gas limit for transactions. (default 60000000)
       --testnet-chain-id uint                  Chain ID of the custom test network.


### PR DESCRIPTION
Update the "Migrate an Existing Validator" (split keys) quickstart and the CLI reference to match actual charon behavior:

- Add `--cluster-dir=/opt/charon/cluster` to the example docker command; without it the cluster is created in `./node*`, contradicting the page's `./cluster` tree and the zip step.
- Document that `deposit-data-*.json` files ARE re-created in split mode, signed with the existing validator keys using the provided withdrawal addresses, and add a warning not to submit them for already-activated validators. The page previously omitted these files entirely.
- Match the command output block to actual charon output (`Created charon cluster`, cluster dir path, deposit-data files).
- Extend the v1.8.0 note: manual keystore preparation is required when specifying an exact list of withdrawal **or fee recipient** addresses.
- Update the `--split-existing-keys` flag description in the CLI reference.

Note: the fee-recipient ordering note and the updated flag description correspond to ObolNetwork/charon#4577 and apply from the charon release containing it; the deposit data documentation is accurate for current releases as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)