### PR TITLE
Align test command docs with charon behavior

### DIFF
--- a/advanced-and-troubleshooting/troubleshooting/test_command.md
+++ b/advanced-and-troubleshooting/troubleshooting/test_command.md
@@ -9,10 +9,10 @@ This page aims to give guidance on the causes, and potential for troubleshooting
 
 ## Running test commands
 
-Below are sample invocations for each deployment method. Replace placeholder values (e.g. `<PEER_ENRS>`, `<BEACON_ENDPOINT>`) with your actual configuration. For full details on all available flags, refer to the [Test a Cluster](../../run-a-dv/prepare/test-a-cluster.md) page.
+Below are sample invocations for each deployment method, using `test peers` as the worked example because it needs access to your `.charon` files (the cluster file and the ENR private key), which is why the Docker examples mount a volume. Other test commands take endpoint flags instead (e.g. `--beacon-endpoints`, `--endpoints`) and generally don't need the volume mount. For each command's flags refer to the [Test a Cluster](../../run-a-dv/prepare/test-a-cluster.md) page.
 
 {% hint style="info" %}
-Most test commands require a `--lock-file` or `--definition-file` flag to identify your cluster. There is no default value for these flags in test commands, so you must specify them explicitly. If you have completed DKG, use `--lock-file`; if you have only created a cluster definition, use `--definition-file`.
+Only the `peers` command uses your cluster files to identify peers. There is no default value for these flags, so you must specify them explicitly: if you have completed DKG use `--lock-file`; if you have only created a cluster definition use `--definition-file`. For `test all` the equivalents are `--peers-lock-file` and `--peers-definition-file`. The `beacon`, `validator`, `mev` and `infra` commands do not accept these flags: `beacon`, `validator` and `mev` target the endpoints you pass them, while `infra` tests the local machine and internet connection.
 {% endhint %}
 
 {% tabs %}
@@ -21,10 +21,10 @@ If you are using the [CDVN](https://github.com/ObolNetwork/charon-distributed-va
 
 ```sh
 # Run from within the charon-distributed-validator-node/ directory
-docker run --rm -u $(id -u):$(id -g) -v "$(pwd):/opt/charon" obolnetwork/charon:v1.10.0 alpha test <COMMAND> \
+docker run --rm -u $(id -u):$(id -g) -v "$(pwd):/opt/charon" obolnetwork/charon:v1.10.0 alpha test peers \
   --lock-file="/opt/charon/.charon/cluster-lock.json" \
-  --private-key-file="/opt/charon/.charon/charon-enr-private-key" \
-  [FLAGS]
+  --private-key-file="/opt/charon/.charon/charon-enr-private-key"
+  # add any other flags here, e.g. --timeout=1h or --keep-alive=30m
 ```
 {% endtab %}
 
@@ -33,9 +33,9 @@ On DappNode, you can run test commands by executing them inside the Charon conta
 
 ```sh
 # Via docker exec (find your container name with `docker ps`)
-docker exec -it DAppNodePackage-hoodi-obol.dnp.dappnode.eth charon alpha test <COMMAND> \
-  --lock-file=".charon/cluster-lock.json" \
-  [FLAGS]
+docker exec -it DAppNodePackage-hoodi-obol.dnp.dappnode.eth charon alpha test peers \
+  --lock-file=".charon/cluster-lock.json"
+  # add any other flags here, e.g. --timeout=1h or --keep-alive=30m
 ```
 
 {% hint style="info" %}
@@ -51,9 +51,9 @@ For Kubernetes deployments using the [Obol Helm charts](https://github.com/ObolN
 kubectl get pods -n dv-pod -l app.kubernetes.io/instance=my-dv-pod
 
 # Exec into the pod and run the test
-kubectl exec -it -n dv-pod my-dv-pod-0 -- charon alpha test <COMMAND> \
-  --lock-file=".charon/cluster-lock.json" \
-  [FLAGS]
+kubectl exec -it -n dv-pod my-dv-pod-0 -- charon alpha test peers \
+  --lock-file=".charon/cluster-lock.json"
+  # add any other flags here, e.g. --timeout=1h or --keep-alive=30m
 ```
 {% endtab %}
 
@@ -61,9 +61,9 @@ kubectl exec -it -n dv-pod my-dv-pod-0 -- charon alpha test <COMMAND> \
 If you have the Charon binary installed directly, run test commands from the directory containing your `.charon` folder.
 
 ```sh
-charon alpha test <COMMAND> \
-  --lock-file=".charon/cluster-lock.json" \
-  [FLAGS]
+charon alpha test peers \
+  --lock-file=".charon/cluster-lock.json"
+  # add any other flags here, e.g. --timeout=1h or --keep-alive=30m
 ```
 {% endtab %}
 {% endtabs %}
@@ -106,9 +106,10 @@ Same causes as PingMeasure test apply here.
 
 ### Self
 
-#### Libp2pTCPPortOpenTest
+#### Libp2pTCPPortOpen
 
-* There might be another process running on the designated port (tcp/3610 by default).
+* This test only performs a real check when you pass `--p2p-tcp-address` (there is no default). If you omit the flag, the test has no address to dial, so it is effectively skipped but still reports `OK` — do not read that as a successful port check. Always provide `--p2p-tcp-address` when you want the port-open check to actually run.
+* The port specified in `--p2p-tcp-address` might already be in use by another process, or be blocked by a firewall.
 * The process might have died.
 
 ## Beacon
@@ -124,9 +125,9 @@ Same causes as PingMeasure test apply here.
 
 #### Version
 
-* The beacon node version is not compatible with charon.
+* This test fetches and records the beacon node's version string; it does not assess compatibility with charon. A failure means the version endpoint could not be reached or its response could not be parsed.
 
-#### IsSynced
+#### Synced
 
 * Beacon node is not synced to the network.
 
@@ -140,9 +141,9 @@ This is a load test, to enable it add the `--load-test` flag.
 
 Same causes as PingMeasure test apply here.
 
-#### Simulation
+#### Simulate1, Simulate10, Simulate100, Simulate500, Simulate1000
 
-This is a load test, to enable it add the `--load-test` flag.
+These are load tests, enabled by adding the `--load-test` flag. Each test simulates the workload for the number of validators in its name. (Setting `--simulation-custom=<N>` runs an additional simulation for N validators, reported as `Simulate<N>`.)
 
 Same causes as PingMeasure test apply here and additionally:
 
@@ -178,10 +179,7 @@ Same causes as PingMeasure test apply here.
 Same causes as PingMeasure test apply here and additionally:
 
 * MEV relay might be too slow in block production.
-
-#### CreateMultipleBlocks
-
-Same causes as CreateBlock test apply here.
+* Setting `--number-of-payloads` greater than 1 requests that many blocks; the result is still reported under the `CreateBlock` name.
 
 ## Infra
 
@@ -215,8 +213,8 @@ Same causes as CreateBlock test apply here.
 
 #### InternetDownloadSpeed
 
-* Your internet download speed from the nearest test server is too low. Download speed is expected to be at least above 10Mb/s and at best above 50Mb/s.
+* Your internet download speed from the nearest test server is too low. Download speed is expected to be at least above 15Mb/s and at best above 50Mb/s.
 
 #### InternetUploadSpeed
 
-* Your internet upload speed to the nearest test server is too low. Upload speed is expected to be at least above 10Mb/s and at best above 50Mb/s.
+* Your internet upload speed to the nearest test server is too low. Upload speed is expected to be at least above 15Mb/s and at best above 50Mb/s.

--- a/run-a-dv/prepare/test-a-cluster.md
+++ b/run-a-dv/prepare/test-a-cluster.md
@@ -2,18 +2,20 @@
 
 Charon test commands are designed to help you evaluate the performance and readiness of your candidate cluster. It allows you to test your connection to other Charon peers, the performance of your beacon node(s), the readiness of your validator client, the performance of the MEV relays you will be using and the infrastructure on which you will run the cluster. It prints a performance report to the standard output (which can be omitted with the `--quiet` flag). Pass `--output-json <path>` to also save the report as machine-readable JSON at that path. Because `--quiet` suppresses the stdout report, it must be combined with `--output-json` — using `--quiet` alone is rejected.
 
-
 {% hint style="success" %}
-
 Adding the `--publish` flag to the below commands, and running the command from the directory containing your `.charon` folder, will submit the test results to the [Obol API](../../api/what-is-this-api.md). Publishing your performance reports grows the staking node dataset, and allows Obol and Ethereum development teams to make data-driven choices regarding the required specs for validating Ethereum. We hope you will consider opting in.
-
 {% endhint %}
 
 {% tabs %}
 {% tab title="Executable" %}
+
 #### Test all
 
 Intended for running tests across all categories. Each flag should have a prefix for its category (i.e.: the flag `--endpoints` from the beacon tests becomes `--beacon-endpoints`). For details about each category refer to their respective sections.
+
+{% hint style="warning" %}
+Test all includes test peers command which is expected to be run **before starting a cluster**, otherwise connections might be clashing between the test command libp2p node and the running Charon node. The same data points obtained by running the test can be obtained from the metrics of a running cluster, so running the test on an already running Charon cluster is nonessential.
+{% endhint %}
 
 {% tabs %}
 {% tab title="Regular Test" %}
@@ -590,6 +592,10 @@ https://0x8c4ed5e24fe5c6ae21018437bde147693f68cda427cd1122cf20819c30eda7ed74f72d
 ### Test connection to peers
 
 Run tests towards other Charon peers to evaluate the effectiveness of a potential cluster setup. The command sets up a libp2p node, similarly to what Charon normally does. This test command **has to be run simultaneously with the other peers**. After the node is up it waits for other peers to get their nodes up and running, retrying the connection every 3 seconds. The libp2p node connects to relays (configurable with `p2p-relays` flag) and to other libp2p nodes via TCP. Other peer nodes are discoverable by using their ENRs. Note that for a peer to be successfully discovered, it needs to be connected to the same relay. After completion of the test suite the libp2p node stays alive (duration configurable with `keep-alive` flag) for other peers to continue testing against it. The node can be forcefully stopped as well.
+
+{% hint style="warning" %}
+Test peers is expected to be run **before starting a cluster**, otherwise connections might be clashing between the test command libp2p node and the running Charon node. The same data points obtained by running the test can be obtained from the metrics of a running cluster, so running the test on an already running Charon cluster is nonessential.
+{% endhint %}
 
 To be able to establish direct connection, you have to ensure:
 

--- a/run-a-dv/prepare/test-a-cluster.md
+++ b/run-a-dv/prepare/test-a-cluster.md
@@ -1,6 +1,6 @@
 # Test a Cluster
 
-Charon test commands are designed to help you evaluate the performance and readiness of your candidate cluster. It allows you to test your connection to other Charon peers, the performance of your beacon node(s), the readiness of your validator client, the performance of the MEV relays you will be using and the infrastructure on which you will run the cluster. It prints a performance report to the standard output (which can be omitted with the `--quiet` flag) and a machine-readable JSON format of the report if the `--output-json` flag is set.
+Charon test commands are designed to help you evaluate the performance and readiness of your candidate cluster. It allows you to test your connection to other Charon peers, the performance of your beacon node(s), the readiness of your validator client, the performance of the MEV relays you will be using and the infrastructure on which you will run the cluster. It prints a performance report to the standard output (which can be omitted with the `--quiet` flag). Pass `--output-json <path>` to also save the report as machine-readable JSON at that path. Because `--quiet` suppresses the stdout report, it must be combined with `--output-json` — using `--quiet` alone is rejected.
 
 
 {% hint style="success" %}
@@ -309,7 +309,7 @@ docker run --network="charon-distributed-validator-node_dvnode" -u $(id -u):$(id
   --beacon-endpoints="http://lighthouse:5052/" \
   --beacon-simulation-file-dir="/opt/charon/test" \
   --beacon-load-test \
-  --validator-api-address="lodestar:5064" \
+  --validator-validator-api-address="lodestar:5064" \
   --mev-endpoints="\
 https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live,\
 https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,\
@@ -343,7 +343,7 @@ docker run --network="charon-distributed-validator-node_dvnode" -u $(id -u):$(id
   --beacon-endpoints="http://lighthouse:5052/" \
   --beacon-simulation-file-dir="/opt/charon/test" \
   --beacon-load-test \
-  --validator-api-address="lodestar:5064" \
+  --validator-validator-api-address="lodestar:5064" \
   --mev-endpoints="\
 https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live,\
 https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,\
@@ -376,7 +376,7 @@ docker run --network="charon-distributed-validator-node_dvnode" -u $(id -u):$(id
   --beacon-endpoints="http://lighthouse:5052/" \
   --beacon-simulation-file-dir="/opt/charon/test" \
   --beacon-load-test \
-  --validator-api-address="lodestar:5064" \
+  --validator-validator-api-address="lodestar:5064" \
   --mev-endpoints="\
 https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live,\
 https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,\
@@ -508,7 +508,7 @@ kubectl exec -it -n dv-pod my-dv-pod-0 -- charon alpha test all \
   --peers-enrs="enr:-HW4QMno_MB_ID6GFVxoIQAHHVHZZZjzFctxtX2tm9D95tvaPbHathi8YUP8jh8v2YUAVu2fYWEOB_BT14pt8QgiGg2AgmlkgnY0iXNlY3AyNTZrMaECdpnK83s0dbBwCaEfDIkQ-3nJkkC93STvv6Vmi0bYlzg,enr:-HW4QO2vefLueTBEUGly5hkcpL7NWdMKWx7Nuy9f7z6XZInCbFAc0IZj6bsnmj-Wi4ElS6jNa0Mge5Rkc2WGTVemas2AgmlkgnY0iXNlY3AyNTZrMaECR9SmYQ_1HRgJmNxvh_ER2Sxx78HgKKgKaOkCROYwaDY" \
   --beacon-endpoints="http://lighthouse:5052/" \
   --beacon-load-test \
-  --validator-api-address="lodestar:5064" \
+  --validator-validator-api-address="lodestar:5064" \
   --mev-endpoints="\
 https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live,\
 https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,\
@@ -538,7 +538,7 @@ kubectl exec -it -n dv-pod my-dv-pod-0 -- charon alpha test all \
   --peers-definition-file="./.charon/cluster-definition.json" \
   --beacon-endpoints="http://lighthouse:5052/" \
   --beacon-load-test \
-  --validator-api-address="lodestar:5064" \
+  --validator-validator-api-address="lodestar:5064" \
   --mev-endpoints="\
 https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live,\
 https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,\
@@ -568,7 +568,7 @@ kubectl exec -it -n dv-pod my-dv-pod-0 -- charon alpha test all \
   --peers-lock-file="./.charon/cluster-lock.json" \
   --beacon-endpoints="http://lighthouse:5052/" \
   --beacon-load-test \
-  --validator-api-address="lodestar:5064" \
+  --validator-validator-api-address="lodestar:5064" \
   --mev-endpoints="\
 https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live,\
 https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net,\


### PR DESCRIPTION
Corrects the `charon alpha test` documentation to match the actual charon binary, verified against a locally built binary (v1.11.0-dev) and the charon source.

## `advanced-and-troubleshooting/troubleshooting/test_command.md`

- Rename test cases to their real names: `Libp2pTCPPortOpenTest` → `Libp2pTCPPortOpen`, `IsSynced` → `Synced`, `Simulation` → `Simulate1/10/100/500/1000`.
- Remove the `CreateMultipleBlocks` section — no such test exists; setting `--number-of-payloads > 1` is still reported under `CreateBlock`.
- Clarify `Libp2pTCPPortOpen`: it only performs a real check when `--p2p-tcp-address` is passed (no default); otherwise it reports `OK` without dialing.
- Correct the `Version` test description: it records the beacon node's version string and does not assess charon compatibility.
- Update internet download/upload thresholds from 10Mb/s to 15Mb/s to match `internetDownloadSpeedMbpsPoor`/`internetUploadSpeedMbpsPoor`.
- Note that `--simulation-custom=<N>` runs an additional simulation reported as `Simulate<N>`.
- Rework the "Running test commands" intro and hint: use `test peers` as the worked example, explain which commands need cluster files (`--lock-file`/`--definition-file`, and `--peers-lock-file`/`--peers-definition-file` for `test all`), and clarify that `infra` tests the local machine rather than an endpoint.

## `run-a-dv/prepare/test-a-cluster.md`

- Fix the `test all` examples to use `--validator-validator-api-address` (the validator category prefix applied to `--validator-api-address`).
- Clarify `--output-json <path>` behavior and that `--quiet` must be combined with `--output-json` (running `--quiet` alone is rejected).
