### PR TITLE
docs(obol-stack): fix v0.13.0 install quickstart mismatches

### DIFF
--- a/obol-stack/README.md
+++ b/obol-stack/README.md
@@ -27,7 +27,7 @@ The cluster runs entirely on your machine via [k3d](https://k3d.io/) (Kubernetes
 * **Sell what your agent builds** — `obol sell demo` deploys a payment-gated HTTP service in one command. Use it as the starting point for selling inference, indexed data, or any HTTP API for $OBOL or USDC micropayments.
 * **Native $OBOL micropayments with sponsored gas on mainnet** — when buyers pay in $OBOL on Ethereum mainnet, the Obol facilitator sponsors the on-chain settlement gas. Buyers sign an [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) permit off-chain and never need ETH. Sellers receive $OBOL directly to their agent wallet.
 * **Multiple network support** — sync local Ethereum nodes (mainnet, sepolia, hoodi), Aztec sequencers, and more. Built-in eRPC routes to public RPCs when no local node is present.
-* **Public access** — expose only the routes you choose (`/services/<name>/*` and discovery metadata) via a Cloudflare quick tunnel. Internal routes (frontend, eRPC) stay locked to `obol.stack`.
+* **Public access** — when you sell, a Cloudflare tunnel exposes only the routes you choose (`/services/<name>/*` and discovery metadata). The tunnel stays **dormant** after a plain `obol stack up` until the first sell workflow or `obol tunnel restart` / `obol tunnel setup`. Internal routes (frontend, eRPC) stay locked to `obol.stack`.
 * **Unique deployments** — every install gets a uniquely-namespaced deployment, so multiple stacks coexist on one machine.
 
 ## CLI overview
@@ -50,13 +50,13 @@ When you run `obol stack up`, the following services are deployed automatically:
 
 | Service | Namespace | Purpose |
 | --- | --- | --- |
-| **Hermes (default agent)** | `hermes-obol-agent` | AI agent + dashboard, with its own Ethereum signing wallet |
+| **Hermes (default agent)** | `hermes-obol-agent` | AI agent + dashboard, with its own Ethereum signing wallet (skipped if no LLM is configured) |
 | **Traefik** | `traefik` | Gateway API ingress controller |
-| **Cloudflared** | `traefik` | Cloudflare tunnel connector for public routes |
+| **Cloudflared** | `traefik` | Tunnel connector chart — **dormant** until first sell / `obol tunnel restart` / permanent `tunnel setup` |
 | **eRPC** | `erpc` | Unified RPC load balancer (local nodes + public fallbacks) |
-| **Obol Frontend** | `obol-frontend` | Web management dashboard (local-only) |
+| **Obol Frontend** | `obol-frontend` | Web management dashboard (local-only; `Host: obol.stack`) |
 | **Monitoring** | `monitoring` | Prometheus + kube-prometheus-stack |
-| **LiteLLM** | `llm` | OpenAI-compatible LLM gateway (Ollama, Anthropic, OpenAI, custom endpoints) |
+| **LiteLLM** | `llm` | OpenAI-compatible LLM gateway (Ollama, Anthropic, OpenAI, OpenRouter, custom endpoints) |
 | **x402 verifier + ServiceOffer controller** | `x402` | Payment gating + reconciliation of payment-gated services |
 
 ## Use it from Claude Code
@@ -109,7 +109,7 @@ Running full Ethereum nodes requires significant disk space. Mainnet execution c
 +---------------------------------------------------------+
 |  k3d Cluster                                            |
 |  +-- Traefik Gateway (ports 80, 8080, 443, 8443)        |
-|  +-- Cloudflared (public tunnel)                        |
+|  +-- Cloudflared (dormant until sell / tunnel setup)    |
 |  +-- LiteLLM (LLM gateway)                              |
 |  +-- eRPC (RPC load balancer)                           |
 |  +-- Obol Frontend (web dashboard, local-only)          |

--- a/obol-stack/faq.md
+++ b/obol-stack/faq.md
@@ -70,17 +70,52 @@ rm -rf ~/.config/obol ~/.local/share/obol
 
 ### The installer cannot modify /etc/hosts
 
-Manually add the entry:
+Manually add the entry, then start (or re-start) the stack:
 
 ```shell
 echo "127.0.0.1 obol.stack" | sudo tee -a /etc/hosts
+obol stack init
+obol stack up
+# If no LLM was configured, Hermes was skipped:
+obol model setup
+obol agent init
 ```
+
+A failed hosts write during install or `obol stack up` is a **warning**, not a hard failure — the CLI and cluster can still be installed. `stack up` will also try to register agent hostnames (`obol-agent.obol.stack`, …).
+
+### How do I skip sudo password prompts (CI / automation)?
+
+Set:
+
+```shell
+export OBOL_NONINTERACTIVE=true
+```
+
+Hosts updates then fail fast if sudo is not already cached (or NOPASSWD). Pre-write `/etc/hosts`, or run `sudo -v` once in the same TTY before non-interactive commands.
+
+### Why is there no Hermes agent after install?
+
+Usually there is **no model in LiteLLM**: Ollama was skipped at install and no cloud provider was configured. Configure a model, then create the agent:
+
+```shell
+obol model setup
+obol agent init
+obol hermes chat
+```
+
+### Why does `http://localhost:8080` return 404?
+
+Traefik serves the frontend only for **`Host: obol.stack`**. Open **`http://obol.stack:8080`** (or `http://obol.stack/` if port 80 is mapped). Ensure `/etc/hosts` contains `127.0.0.1 obol.stack`.
+
+### Is the Cloudflare tunnel always on?
+
+No. After a plain `obol stack up`, the tunnel is **dormant**. It activates on the first selling workflow (e.g. `obol sell demo`) or with `obol tunnel restart`. For a permanent hostname, use `obol tunnel setup` — see [Set up a permanent URL](permanent-url.md).
 
 ## The Obol Agent
 
 ### What's the default agent?
 
-[Hermes](https://github.com/NousResearch/hermes-agent) is the default Obol Agent runtime as of v0.9.0. `obol stack up` provisions a default Hermes instance in the `hermes-obol-agent` namespace, with its own Ethereum signing wallet and a built-in skill library.
+[Hermes](https://github.com/NousResearch/hermes-agent) is the default Obol Agent runtime. `obol stack up` provisions a default Hermes instance in the `hermes-obol-agent` namespace (when a model is available), with its own Ethereum signing wallet and a built-in skill library.
 
 OpenClaw remains supported as an optional alternate runtime — `obol agent new --runtime openclaw` if you want one.
 

--- a/obol-stack/quickstart.md
+++ b/obol-stack/quickstart.md
@@ -22,7 +22,14 @@ Verify Docker is running with `docker info` before proceeding.
 ollama pull qwen3.5:4b   # or qwen3.5:9b on a 16 GB+ machine
 ```
 
-If you'd rather route through Anthropic or OpenAI, you can configure that with `obol model setup` after the cluster is up.
+The installer may offer to install Ollama. **If you decline and do not configure a cloud/custom model**, `obol stack up` has nothing to put in LiteLLM and **skips the default Hermes agent**. Fix after install with:
+
+```shell
+obol model setup          # interactive; or e.g. --provider openrouter
+obol agent init
+```
+
+You can also use Anthropic, OpenAI, OpenRouter, Venice, or any OpenAI-compatible endpoint via `obol model setup` after the cluster is up.
 
 ## Step 1: Install the Obol Stack
 
@@ -36,7 +43,7 @@ The installer will:
 
 1. Validate that Docker is running.
 2. Install the `obol` CLI binary and dependencies (kubectl, helm, k3d, helmfile, k9s).
-3. Configure your PATH and add `obol.stack` to `/etc/hosts`.
+3. Configure your PATH and try to add `obol.stack` to `/etc/hosts`.
 4. Offer to start the cluster immediately.
 
 {% tabs %}
@@ -54,8 +61,10 @@ Files are installed to:
 
 {% tab title="Specific version" %}
 ```shell
-OBOL_RELEASE=v0.9.0 bash <(curl -fsSL https://stack.obol.org)
+OBOL_RELEASE=v0.13.0 bash <(curl -fsSL https://stack.obol.org)
 ```
+
+Use the current tag from the [GitHub releases](https://github.com/ObolNetwork/obol-stack/releases) page when newer than v0.13.0.
 {% endtab %}
 
 {% tab title="Development mode" %}
@@ -69,6 +78,21 @@ Development mode uses a local `.workspace/` directory and runs `go run` instead 
 {% endtab %}
 {% endtabs %}
 
+{% hint style="warning" %}
+**If `/etc/hosts` cannot be updated** (no sudo, or you cancel the password prompt), the installer still finishes — it does not hard-fail. Add the host, then start the stack yourself:
+
+```shell
+echo "127.0.0.1 obol.stack" | sudo tee -a /etc/hosts
+obol stack init
+obol stack up
+obol agent init   # if Hermes was skipped (no model yet)
+```
+
+`obol stack up` will try hosts again (including agent hostnames such as `obol-agent.obol.stack`). A failed write is a **warning**, not a stop.
+
+For CI/automation without a sudo password prompt, set `OBOL_NONINTERACTIVE=true` (hosts update fails fast unless sudo is already cached or NOPASSWD is configured).
+{% endhint %}
+
 ## Step 2: Start the stack
 
 ```shell
@@ -76,11 +100,23 @@ obol stack init
 obol stack up
 ```
 
-`obol stack up` does a lot on first run — 2–5 minutes is normal — and ends with a default Hermes agent running in the `hermes-obol-agent` namespace, with its own Ethereum signing wallet.
+`obol stack up` does a lot on first run — 2–5 minutes is normal. When a model is available it deploys a default Hermes agent in the `hermes-obol-agent` namespace with its own Ethereum signing wallet. The **Cloudflare tunnel stays dormant** until the first selling workflow or an explicit `obol tunnel restart` / `obol tunnel setup`.
 
 {% hint style="info" %}
 First startup pulls several Docker images. If it stalls, check `obol kubectl get pods -A` to see what's still pending.
 {% endhint %}
+
+### Open the local UI
+
+```text
+http://obol.stack:8080
+```
+
+Use the **`obol.stack` hostname**, not `localhost`. Traefik routes the frontend (and eRPC) only for `Host: obol.stack`. **`http://localhost:8080` returns 404** even when the stack is healthy.
+
+* Prefer **`:8080`** on macOS when port 80 is unavailable (or after editing `~/.config/obol/k3d.yaml` to drop privileged 80/443 binds).
+* If port 80 is mapped, `http://obol.stack/` works too.
+* Hermes dashboard (separate host): `http://obol-agent.obol.stack` (add `:8080` if that is your ingress).
 
 ## Step 3: Chat with your agent
 
@@ -199,7 +235,7 @@ obol sell status <name>           # ServiceOffer reconciliation state
 ```
 
 {% hint style="info" %}
-`obol stack up` gives you a **temporary** tunnel URL that changes on every restart. When you're ready to sell, give your stack a stable hostname — see [Set up a permanent URL](permanent-url.md).
+A plain `obol stack up` leaves the tunnel **dormant**. Selling (`obol sell demo`, `obol sell http`, …) or `obol tunnel restart` activates a temporary quick-tunnel URL (it can change on restart). For a stable public hostname, use [Set up a permanent URL](permanent-url.md) (`obol tunnel setup --hostname …`).
 {% endhint %}
 
 ## Stopping and cleaning up

--- a/obol-stack/quickstart.md
+++ b/obol-stack/quickstart.md
@@ -109,7 +109,7 @@ First startup pulls several Docker images. If it stalls, check `obol kubectl get
 ### Open the local UI
 
 ```text
-http://obol.stack:8080
+http://obol.stack
 ```
 
 Use the **`obol.stack` hostname**, not `localhost`. Traefik routes the frontend (and eRPC) only for `Host: obol.stack`. **`http://localhost:8080` returns 404** even when the stack is healthy.


### PR DESCRIPTION
## Summary

Aligns live GitBook Obol Stack pages with v0.13.0 product behavior after hackathon installer feedback:

| Topic | Change |
|-------|--------|
| Pin example | `OBOL_RELEASE=v0.13.0` (was v0.9.0) |
| `/etc/hosts` | Resume path: hosts → `stack init` / `up` / `agent init` |
| `OBOL_NONINTERACTIVE` | Documented for CI / no sudo prompt |
| Ollama decline | Explains Hermes skip + `model setup` / `agent init` |
| Tunnel | Dormant until sell / `tunnel restart` / permanent setup |
| Local UI | `http://obol.stack:8080`; Host header; localhost 404 |

Pages: `obol-stack/README.md` (Intro), `quickstart.md`, `faq.md`.

Companion in-repo stack docs: ObolNetwork/obol-stack#755

## Test plan

- [ ] Preview on GitBook after merge
- [ ] Spot-check https://docs.obol.org/obol-stack/quickstart for pin, hosts, 8080, tunnel